### PR TITLE
New dependency for Gemfile.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ source "https://rubygems.org"
 gem "github-pages", "~> 228", group: :jekyll_plugins
 
 gem "webrick", "~> 1.8"
+
+gem 'faraday-retry'
+
+gem 'wdm', '>= 0.1.0' if Gem.win_platform?


### PR DESCRIPTION
Included a new dependency `faraday-retry` ([read more here](https://github.com/lostisland/faraday-retry)). Also, to avoid "_polling_", a new extra line was added to the **Gemfile**. No more warnings when executing a local server:

![image](https://github.com/J35HN/J35HN.github.io/assets/72514826/a10f8223-11cd-4204-b86a-8e436b01f809)
